### PR TITLE
chore: add example docker-compose

### DIFF
--- a/blockchain.dockerfile
+++ b/blockchain.dockerfile
@@ -1,0 +1,16 @@
+FROM node:16
+
+RUN mkdir -p /deployment/
+
+COPY ./ /deployment/
+
+WORKDIR /deployment/packages/overseer
+
+RUN yarn add concurrently
+
+RUN yarn add wait-on
+
+RUN yarn build:contract
+
+CMD ["/bin/bash", "-c", "yarn concurrently \"yarn run:blockchain\" \"wait-on tcp:8545 && yarn deploy:local\""]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3.8'
+services:
+  worker0:
+    image: greenproof-worker
+    build: 
+      context: .
+      dockerfile: worker.dockerfile
+    ports:
+      - "3030:3030"
+
+  worker1:
+    image: greenproof-worker
+    build: 
+      context: .
+      dockerfile: worker.dockerfile
+    ports:
+      - "3031:3030"
+    
+  worker2:
+    image: greenproof-worker
+    build: 
+      context: .
+      dockerfile: worker.dockerfile
+    ports:
+      - "3032:3030"
+    
+  overseer:
+    image: greenproof-overseer
+    build: 
+      context: .
+      dockerfile: overseer.dockerfile
+    ports:
+      - "3040:3000"
+    depends_on:
+      - blockchain
+    environment:
+      - RPC_HOST=http://blockchain:8545
+
+  blockchain:
+    image: greenproof-blockchain
+    build:
+      context: .
+      dockerfile: blockchain.dockerfile
+    ports:
+      - "8545:8545"
+

--- a/overseer.dockerfile
+++ b/overseer.dockerfile
@@ -1,0 +1,11 @@
+FROM node:16
+
+RUN mkdir -p /deployment/
+
+COPY ./ /deployment/
+
+WORKDIR /deployment/packages/overseer
+
+RUN yarn build
+
+CMD ["/bin/bash", "-c", "node dist/main"]

--- a/packages/example/Dockerfile
+++ b/packages/example/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:16
+
+RUN mkdir -p /deployment/worker
+
+COPY ./ /deployment/worker
+COPY ../node_modules/ /deployment/node_modules
+
+WORKDIR /deployment/worker
+
+# RUN yarn
+
+# RUN yarn build
+
+CMD ["/bin/bash", "-c", "node dist/main"]

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -1,37 +1,39 @@
+import { NestFactory } from '@nestjs/core';
 import type { Reading, ReadingQuery} from 'greenproof-worker';
 import { WorkerBuilder } from 'greenproof-worker';
 import { matchingAlgorithm } from './algorithm';
+import { AppModule } from './app.module';
 import { produceData } from './data-producer';
 
 // Launch Nest.js application
-// async function bootstrap() {
-//   const app = await NestFactory.create(AppModule);
-//   await app.listen(3000);
-// }
-// bootstrap();
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();
 
-const data = produceData();
+// const data = produceData();
 
-const filterReading = (query: ReadingQuery) => (reading: Reading) => {
-  const isGreater = reading.timestamp >= (query.from ?? new Date(0));
-  const isSmaller = reading.timestamp <= (query.to ?? new Date(Number.MAX_SAFE_INTEGER));
+// const filterReading = (query: ReadingQuery) => (reading: Reading) => {
+//   const isGreater = reading.timestamp >= (query.from ?? new Date(0));
+//   const isSmaller = reading.timestamp <= (query.to ?? new Date(Number.MAX_SAFE_INTEGER));
 
-  return isGreater && isSmaller;
-};
+//   return isGreater && isSmaller;
+// };
 
-// Or bootstrap worker with a builder
-(async () => {
-  const matchingFacade = await new WorkerBuilder()
-    .setMatchingAlgorithm(matchingAlgorithm)
-    .setDataSource({
-      getConsumptions: async (query: ReadingQuery) => data.consumptions.filter(filterReading(query)),
-      getGenerations: async (query: ReadingQuery) => data.generations.filter(filterReading(query)),
-      getPreferences: async () => data.preferences,
-    })
-    .setResultSource({
-      receiveMatchingResult: async (result) => console.log(JSON.stringify(result, null, 2)),
-    })
-    .compile();
+// // Or bootstrap worker with a builder
+// (async () => {
+//   const matchingFacade = await new WorkerBuilder()
+//     .setMatchingAlgorithm(matchingAlgorithm)
+//     .setDataSource({
+//       getConsumptions: async (query: ReadingQuery) => data.consumptions.filter(filterReading(query)),
+//       getGenerations: async (query: ReadingQuery) => data.generations.filter(filterReading(query)),
+//       getPreferences: async () => data.preferences,
+//     })
+//     .setResultSource({
+//       receiveMatchingResult: async (result) => console.log(JSON.stringify(result, null, 2)),
+//     })
+//     .compile();
 
-  await matchingFacade.match(new Date('2022-04-01T01:00:00.000Z'));
-})();
+//   await matchingFacade.match(new Date('2022-04-01T01:00:00.000Z'));
+// })();

--- a/packages/overseer/src/example/example.ts
+++ b/packages/overseer/src/example/example.ts
@@ -1,7 +1,7 @@
 import type { OverseerConfig, BlockchainConfig, EventListeners } from '../types';
 
 export const localBlockchainConfig: BlockchainConfig = {
-  rpcHost: 'http://localhost:8545',
+  rpcHost: process.env.RPC_HOST ?? 'http://localhost:8545',
   contractAddress: '0x5fbdb2315678afecb367f032d93f642f64180aa3',
   overseerPrivateKey: '0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba',
 };

--- a/worker.dockerfile
+++ b/worker.dockerfile
@@ -1,0 +1,9 @@
+FROM node:16
+
+RUN mkdir -p /deployment/
+
+COPY ./ /deployment/
+
+WORKDIR /deployment/packages/example
+
+CMD ["/bin/bash", "-c", "node dist/main"]


### PR DESCRIPTION
Temporary docker-compose - the workers are added manually in order to have the ability provide different envs, which is impossible with docker-compose scaling. This will be later handled by kubernetes or similar solution.

The dockerfiles are in root so that they have all dependencies, since the projects are not released for now, I will change this once we publish them.