### PR TITLE
feat/GP-180/prevent-enroled-workers-removal

### DIFF
--- a/packages/voting-contract/contracts/MatchVoting.sol
+++ b/packages/voting-contract/contracts/MatchVoting.sol
@@ -203,6 +203,8 @@ contract MatchVoting is Ownable {
         if (!isWorker(workerToRemove)) {
             revert WorkerWasNotAdded();
         }
+        require(workerToRemove.isWorker(claimManagerAddress, workerRole) == false,
+        "Not allowed: still enrolled as worker");
         uint256 workerIndex = workerToIndex[workerToRemove];
         // Copy last element to fill the missing place in array
         address payable workerToMove = workers[numberOfWorkers - 1];


### PR DESCRIPTION
This PR adds a role checking in Voting-Contract before removing a worker.
Workers has to lose their worker role before being removed from workers list.

[Jira Story](https://energyweb.atlassian.net/browse/GP-180?atlOrigin=eyJpIjoiNzNiM2U5MDMzOWRkNDM1Nzg3N2I4ZTRhZmFmYThiNmUiLCJwIjoiaiJ9)

### associated tasks

- [x]  Verifying the workers does not have the worker role when calling `removeWorker` function in the voting contract
- [x] Adding unit tests
