### PR TITLE
fix(voting-contract): removing worker

### DIFF
--- a/packages/voting-contract/contracts/MatchVoting.sol
+++ b/packages/voting-contract/contracts/MatchVoting.sol
@@ -71,8 +71,10 @@ contract MatchVoting is Ownable {
     mapping(string => Voting) public matchInputToVoting;
 
     modifier onlyEnrolledWorkers(address _worker) {
-        require(_worker.isWorker(claimManagerAddress, workerRole),
-        "Access denied: not enrolled as worker");
+        require(
+            _worker.isWorker(claimManagerAddress, workerRole),
+            "Access denied: not enrolled as worker"
+        );
         _;
     }
 
@@ -190,7 +192,11 @@ contract MatchVoting is Ownable {
         return matchInputs.length;
     }
 
-    function addWorker(address payable workerAddress) external onlyOwner onlyEnrolledWorkers(workerAddress) {
+    function addWorker(address payable workerAddress)
+        external
+        onlyOwner
+        onlyEnrolledWorkers(workerAddress)
+    {
         if (isWorker(workerAddress)) {
             revert WorkerAlreadyAdded();
         }
@@ -203,15 +209,21 @@ contract MatchVoting is Ownable {
         if (!isWorker(workerToRemove)) {
             revert WorkerWasNotAdded();
         }
-        require(workerToRemove.isWorker(claimManagerAddress, workerRole) == false,
-        "Not allowed: still enrolled as worker");
-        uint256 workerIndex = workerToIndex[workerToRemove];
-        // Copy last element to fill the missing place in array
-        address payable workerToMove = workers[numberOfWorkers - 1];
-        workers[workerIndex] = workerToMove;
-        workerToIndex[workerToMove] = workerIndex;
-        // Delete last element
-        delete workers[numberOfWorkers - 1];
+        require(
+            workerToRemove.isWorker(claimManagerAddress, workerRole) == false,
+            "Not allowed: still enrolled as worker"
+        );
+
+        if (numberOfWorkers > 1) {
+            uint256 workerIndex = workerToIndex[workerToRemove];
+            // Copy last element to fill the missing place in array
+            address payable workerToMove = workers[numberOfWorkers - 1];
+            workers[workerIndex] = workerToMove;
+            workerToIndex[workerToMove] = workerIndex;
+        }
+
+        delete workerToIndex[workerToRemove];
+        workers.pop();
         numberOfWorkers = numberOfWorkers - 1;
     }
 

--- a/packages/voting-contract/test/match-voting.spec.ts
+++ b/packages/voting-contract/test/match-voting.spec.ts
@@ -405,4 +405,44 @@ describe("MatchVoting", () => {
       matchVoting.connect(worker2).cancelExpiredVotings()
     ).to.be.revertedWith("Ownable: caller is not the owner");
   });
+
+  it("should allow to remove workers and add it again", async () => {
+    await matchVoting.addWorker(worker1.address);
+    await matchVoting.addWorker(worker2.address);
+    await matchVoting.addWorker(worker3.address);
+
+    expect(await matchVoting.isWorker(worker1.address)).to.equal(true);
+    expect(await matchVoting.isWorker(worker2.address)).to.equal(true);
+    expect(await matchVoting.isWorker(worker3.address)).to.equal(true);
+
+    await Promise.all(
+      [worker1.address, worker2.address, worker3.address].map(async (a) => {
+        await claimManagerMocked.mock.hasRole
+          .withArgs(a, workerRoleDef, defaultRoleVersion)
+          .returns(false);
+      })
+    );
+
+    await matchVoting.removeWorker(worker1.address);
+    await matchVoting.removeWorker(worker2.address);
+    await matchVoting.removeWorker(worker3.address);
+    expect(await matchVoting.isWorker(worker1.address)).to.equal(false);
+    expect(await matchVoting.isWorker(worker2.address)).to.equal(false);
+    expect(await matchVoting.isWorker(worker3.address)).to.equal(false);
+
+    await Promise.all(
+      [worker1.address, worker2.address, worker3.address].map(async (a) => {
+        await claimManagerMocked.mock.hasRole
+          .withArgs(a, workerRoleDef, defaultRoleVersion)
+          .returns(true);
+      })
+    );
+
+    await matchVoting.addWorker(worker1.address);
+    await matchVoting.addWorker(worker2.address);
+    await matchVoting.addWorker(worker3.address);
+    expect(await matchVoting.isWorker(worker1.address)).to.equal(true);
+    expect(await matchVoting.isWorker(worker2.address)).to.equal(true);
+    expect(await matchVoting.isWorker(worker3.address)).to.equal(true);
+  });
 });


### PR DESCRIPTION
Removing worker doesn't work. Delete should not be used as it sets worker to in array to `0x0` address - which breaks following pushes. Pop removes it entirely. Also workerToIndex needs to be cleared out as well

Fix was tested in: https://github.com/energywebfoundation/greenproof-sdk/pull/78

It was not tested here, because I cannot workaround 

```
require(
            workerToRemove.isWorker(claimManagerAddress, workerRole) == false,
            "Not allowed: still enrolled as worker"
        );
```

May need your help @knzeng-e with testing this method.