### PR TITLE
feat(GreenProof):  Audit-M05-adding the ability to update claimRevocationRegistry

### DIFF
--- a/packages/greenproof-contracts/contracts/Greenproof.sol
+++ b/packages/greenproof-contracts/contracts/Greenproof.sol
@@ -35,6 +35,7 @@ contract Greenproof is SolidStateDiamond {
     event RevokerVersionUpdated(uint256 indexed oldVersion, uint256 indexed newVersion);
     event ClaimerVersionUpdated(uint256 indexed oldVersion, uint256 indexed newVersion);
     event ClaimManagerUpdated(address indexed oldAddress, address indexed newAddress);
+    event ClaimsRevocationRegistryUpdated(address indexed oldAddress, address indexed newAddress);
 
     constructor(GreenproofConfig memory diamondConfig, VotingConfig memory votingConfig, RolesConfig memory rolesConfig) payable {
         require(votingConfig.rewardAmount > 0, "init: Null reward amount");
@@ -62,6 +63,11 @@ contract Greenproof is SolidStateDiamond {
     function updateClaimManager(address newAddress) external {
         address oldAddress = LibClaimManager.setClaimManagerAddress(newAddress);
         emit ClaimManagerUpdated(oldAddress, newAddress);
+    }
+
+    function updateClaimRevocationRegistry(address newAddress) external {
+        address oldAddress = LibClaimManager.setClaimRevocationRegistry(newAddress);
+        emit ClaimsRevocationRegistryUpdated(oldAddress, newAddress);
     }
 
     function updateIssuerVersion(uint256 newVersion) external {

--- a/packages/greenproof-contracts/contracts/libraries/LibClaimManager.sol
+++ b/packages/greenproof-contracts/contracts/libraries/LibClaimManager.sol
@@ -103,6 +103,16 @@ library LibClaimManager {
         claimStore.claimManagerAddress = _newAddress;
     }
 
+    function setClaimRevocationRegistry(address newAddress) internal onlyOwner returns (address oldAddress) {
+        ClaimManagerStorage storage claimStore = getStorage();
+
+        require(newAddress != address(0), "Revocation Registry: null address");
+        require(claimStore.claimsRevocationRegistry != newAddress, "Revocation Registry: Same address");
+
+        oldAddress = claimStore.claimsRevocationRegistry;
+        claimStore.claimsRevocationRegistry = newAddress;
+    }
+
     function getStorage() internal pure returns (ClaimManagerStorage storage ClaimStore) {
         bytes32 position = CLAIM_MANAGER_STORAGE_POSITION;
         assembly {

--- a/packages/greenproof-contracts/test/greenproof.spec.js
+++ b/packages/greenproof-contracts/test/greenproof.spec.js
@@ -153,6 +153,36 @@ describe("GreenproofTest", async function () {
 
     });
 
+    describe("- ClaimRevocationRegistry update tests", () => {
+      it("should revert when updating ClaimRevocationRegistry with Zero address", async () => {
+        const zeroAddress = ethers.constants.AddressZero;
+        await expect(greenproof.updateClaimRevocationRegistry(zeroAddress))
+          .to.be.revertedWith("Revocation Registry: null address");
+      });
+
+      it("should revert when updating ClaimRevocationRegistry with same address", async () => {
+        await expect(greenproof.updateClaimRevocationRegistry(claimsRevocationRegistryMocked.address))
+          .to.be.revertedWith("Revocation Registry: Same address");
+      });
+
+      it("should revert when non owner tries to update ClaimRevocationRegistry Address", async () => {
+        const newRevocationregistry = "0x43a7aEeb21C0dFE55d967d7A58B2Dfe6AEA50d7f";
+        
+        await expect(
+          greenproof.connect(nonOwner).updateClaimRevocationRegistry(newRevocationregistry)
+        ).to.be.revertedWith("Greenproof: ClaimManager facet: Must be contract owner");
+      });
+
+      it("should update ClaimRevocationRegistry Address", async () => {
+        const oldRevocationregistry = claimsRevocationRegistryMocked.address;
+        const newRevocationregistry = "0x43a7aEeb21C0dFE55d967d7A58B2Dfe6AEA50d7f";
+        
+        await expect(greenproof.updateClaimRevocationRegistry(newRevocationregistry))
+          .to.emit(greenproof, "ClaimsRevocationRegistryUpdated").withArgs(oldRevocationregistry, newRevocationregistry);
+      });
+
+    });
+
     describe("- ClaimerRole update tests", () => {
       it("should revert when updating claimerRole version with same version", async () => {
         const sameRoleVersion = 1;


### PR DESCRIPTION
This PR adds functionality for updating the Claim Revocation Registry address.
It implements [M05 audit feedback](https://energyweb.atlassian.net/browse/GP-675)