### PR TITLE
fix(IssuerFacet): using _safeMint to issue certificates

### DIFF
--- a/packages/greenproof-contracts/contracts/facets/IssuerFacet.sol
+++ b/packages/greenproof-contracts/contracts/facets/IssuerFacet.sol
@@ -67,7 +67,7 @@ contract IssuerFacet is SolidStateERC1155, IGreenProof {
         LibIssuer._incrementProofIndex();
         LibIssuer._registerProof(dataHash, generator, amount, issuer.latestCertificateId, voteID);
 
-        _mint(generator, issuer.latestCertificateId, amount, "");
+        _safeMint(generator, issuer.latestCertificateId, amount, "");
         _setTokenURI(issuer.latestCertificateId, tokenUri);
         emit LibIssuer.ProofMinted(issuer.latestCertificateId, amount, generator);
     }


### PR DESCRIPTION
This PR implements[ audit feedback M08](https://energyweb.atlassian.net/browse/GP-678) and provides additional validation before minting certificates.
This validation step is provided by the usage of `_safeMint` function instead of `_mint`, and avoids loss of certificate if the receiver address is a contract not implementing the `ERC1155Receiver` interface.