### PR TITLE
chore(greenproofLibraries):  Audit-L02-explicit constant variable visibility

### DIFF
--- a/packages/greenproof-contracts/contracts/libraries/LibClaimManager.sol
+++ b/packages/greenproof-contracts/contracts/libraries/LibClaimManager.sol
@@ -5,7 +5,7 @@ import {OwnableStorage} from "@solidstate/contracts/access/ownable/Ownable.sol";
 import {IClaimManager} from "../interfaces/IClaimManager.sol";
 
 library LibClaimManager {
-    bytes32 constant CLAIM_MANAGER_STORAGE_POSITION = keccak256("ewc.greenproof.claimManager.diamond.storage");
+    bytes32 private constant CLAIM_MANAGER_STORAGE_POSITION = keccak256("ewc.greenproof.claimManager.diamond.storage");
 
     error NotInitializedClaimManager();
 

--- a/packages/greenproof-contracts/contracts/libraries/LibIssuer.sol
+++ b/packages/greenproof-contracts/contracts/libraries/LibIssuer.sol
@@ -8,7 +8,7 @@ import {ERC1155BaseInternal} from "@solidstate/contracts/token/ERC1155/base/ERC1
 import {ERC1155EnumerableInternal} from "@solidstate/contracts/token/ERC1155/enumerable/ERC1155EnumerableInternal.sol";
 
 library LibIssuer {
-    bytes32 constant ISSUER_STORAGE_POSITION = keccak256("ewc.greenproof.issuer.diamond.storage");
+    bytes32 private constant ISSUER_STORAGE_POSITION = keccak256("ewc.greenproof.issuer.diamond.storage");
 
     struct IssuerStorage {
         uint256 latestCertificateId;

--- a/packages/greenproof-contracts/contracts/libraries/LibReward.sol
+++ b/packages/greenproof-contracts/contracts/libraries/LibReward.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.16;
 import {OwnableStorage} from "@solidstate/contracts/access/ownable/Ownable.sol";
 
 library LibReward {
-    bytes32 constant REWARD_STORAGE_POSITION = keccak256("ewc.greenproof.rewardVoting.diamond.storage");
+    bytes32 private constant REWARD_STORAGE_POSITION = keccak256("ewc.greenproof.rewardVoting.diamond.storage");
 
     /// Invalid call to pay rewards to the winners. Rewards are disabled.
     error RewardsDisabled();

--- a/packages/greenproof-contracts/contracts/libraries/LibVoting.sol
+++ b/packages/greenproof-contracts/contracts/libraries/LibVoting.sol
@@ -7,7 +7,7 @@ import {IVoting} from "../interfaces/IVoting.sol";
 import {MerkleProof} from "@solidstate/contracts/cryptography/MerkleProof.sol";
 
 library LibVoting {
-    bytes32 constant VOTING_STORAGE_POSITION = keccak256("ewc.greenproof.voting.diamond.storage");
+    bytes32 private constant VOTING_STORAGE_POSITION = keccak256("ewc.greenproof.voting.diamond.storage");
 
     struct Voting {
         bytes32[] sessionIDs;


### PR DESCRIPTION
This PR adds explicit visibility for storage constant variable inside facet libraries.
It implements [audit feedback L02](https://energyweb.atlassian.net/browse/GP-680)