### PR TITLE
chore(Greenproof-contracts):  Audit-L07- removing redundant imports

### DIFF
--- a/packages/greenproof-contracts/contracts/facets/IssuerFacet.sol
+++ b/packages/greenproof-contracts/contracts/facets/IssuerFacet.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import {IVoting} from "../interfaces/IVoting.sol";
 import {LibIssuer} from "../libraries/LibIssuer.sol";
 import {LibVoting} from "../libraries/LibVoting.sol";
 import {IGreenProof} from "../interfaces/IGreenProof.sol";

--- a/packages/greenproof-contracts/contracts/facets/VotingFacet.sol
+++ b/packages/greenproof-contracts/contracts/facets/VotingFacet.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.16;
 import {OwnableStorage} from "@solidstate/contracts/access/ownable/Ownable.sol";
 import {IVoting} from "../interfaces/IVoting.sol";
 import {IReward} from "../interfaces/IReward.sol";
-import {LibIssuer} from "../libraries/LibIssuer.sol";
 import {LibReward} from "../libraries/LibReward.sol";
 import {LibVoting} from "../libraries/LibVoting.sol";
 import {LibClaimManager} from "../libraries/LibClaimManager.sol";

--- a/packages/greenproof-contracts/contracts/interfaces/IGreenProof.sol
+++ b/packages/greenproof-contracts/contracts/interfaces/IGreenProof.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import {LibIssuer} from "../libraries/LibIssuer.sol";
-
 interface IGreenProof {
     struct Certificate {
         bool isRevoked;
@@ -23,12 +21,7 @@ interface IGreenProof {
         string memory tokenUri
     ) external;
 
-    function discloseData(
-        string memory key,
-        string memory value,
-        bytes32[] memory dataProof,
-        bytes32 dataHash
-    ) external;
+    function discloseData(string memory key, string memory value, bytes32[] memory dataProof, bytes32 dataHash) external;
 
     function getCertificateOwners(uint256 certificateID) external view returns (address[] memory);
 

--- a/packages/greenproof-contracts/contracts/libraries/LibIssuer.sol
+++ b/packages/greenproof-contracts/contracts/libraries/LibIssuer.sol
@@ -1,11 +1,8 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import {IVoting} from "../interfaces/IVoting.sol";
 import {IGreenProof} from "../interfaces/IGreenProof.sol";
 import {UintUtils} from "@solidstate/contracts/utils/UintUtils.sol";
-import {ERC1155BaseInternal} from "@solidstate/contracts/token/ERC1155/base/ERC1155BaseInternal.sol";
-import {ERC1155EnumerableInternal} from "@solidstate/contracts/token/ERC1155/enumerable/ERC1155EnumerableInternal.sol";
 
 library LibIssuer {
     bytes32 constant ISSUER_STORAGE_POSITION = keccak256("ewc.greenproof.issuer.diamond.storage");

--- a/packages/greenproof-contracts/contracts/libraries/LibProofManager.sol
+++ b/packages/greenproof-contracts/contracts/libraries/LibProofManager.sol
@@ -1,15 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 import {MerkleProof} from "@solidstate/contracts/cryptography/MerkleProof.sol";
-import {ERC1155BaseStorage} from "@solidstate/contracts/token/ERC1155/base/ERC1155BaseInternal.sol";
 
 library LibProofManager {
-
-    function _verifyProof(
-        bytes32 rootHash,
-        bytes32 leaf,
-        bytes32[] memory proof
-    ) internal pure returns (bool) {
+    function _verifyProof(bytes32 rootHash, bytes32 leaf, bytes32[] memory proof) internal pure returns (bool) {
         return MerkleProof.verify(proof, rootHash, leaf);
     }
 }


### PR DESCRIPTION
This PR cleans the codebase by removing redundant imports from contracts.
It implements [audit feedback L07](https://energyweb.atlassian.net/browse/GP-685).