### PR TITLE
chore(Greenproof-contracts): Audit-L08-removing redundant override statement

### DIFF
--- a/packages/greenproof-contracts/contracts/facets/IssuerFacet.sol
+++ b/packages/greenproof-contracts/contracts/facets/IssuerFacet.sol
@@ -47,7 +47,7 @@ contract IssuerFacet is SolidStateERC1155, IGreenProof {
         uint256 volume,
         bytes32[] memory amountProof,
         string memory tokenUri
-    ) external override onlyIssuer {
+    ) external onlyIssuer {
         LibIssuer.IssuerStorage storage issuer = LibIssuer._getStorage();
 
         require(generator != address(0), "issuance must be non-zero");
@@ -81,7 +81,7 @@ contract IssuerFacet is SolidStateERC1155, IGreenProof {
      * @param dataProof - The proofs path to verify that key-value hashed data is part of dataHash merkleTree
      * @param dataHash - The merkleRoot hash of the certified data set.
      */
-    function discloseData(string memory key, string memory value, bytes32[] memory dataProof, bytes32 dataHash) external override onlyIssuer {
+    function discloseData(string memory key, string memory value, bytes32[] memory dataProof, bytes32 dataHash) external onlyIssuer {
         LibIssuer.IssuerStorage storage issuer = LibIssuer._getStorage();
 
         require(issuer.isDataDisclosed[dataHash][key] == false, "Disclose: data already disclosed");
@@ -97,7 +97,7 @@ contract IssuerFacet is SolidStateERC1155, IGreenProof {
      * @param certificateID - the id of the minted certificate
      * @return certificateOwners - The List of all users / wallets holding a share of this `certificateID`.
      */
-    function getCertificateOwners(uint256 certificateID) external view override returns (address[] memory certificateOwners) {
+    function getCertificateOwners(uint256 certificateID) external view returns (address[] memory certificateOwners) {
         certificateOwners = _accountsByToken(certificateID);
     }
 

--- a/packages/greenproof-contracts/contracts/facets/ProofManagerFacet.sol
+++ b/packages/greenproof-contracts/contracts/facets/ProofManagerFacet.sol
@@ -36,11 +36,11 @@ contract ProofManagerFacet is IProofManager, ERC1155EnumerableInternal {
         _claimProof(certificateID, owner, amount);
     }
 
-    function claimProof(uint256 certificateID, uint256 amount) external override {
+    function claimProof(uint256 certificateID, uint256 amount) external {
         _claimProof(certificateID, msg.sender, amount);
     }
 
-    function revokeProof(uint256 certificateID) external override onlyRevoker {
+    function revokeProof(uint256 certificateID) external onlyRevoker {
         LibIssuer.IssuerStorage storage issuer = LibIssuer._getStorage();
         uint256 issuanceDate = issuer.certificates[certificateID].issuanceDate;
 
@@ -55,7 +55,7 @@ contract ProofManagerFacet is IProofManager, ERC1155EnumerableInternal {
         emit ProofRevoked(certificateID);
     }
 
-    function getProof(uint256 certificateID) external view override returns (IGreenProof.Certificate memory proof) {
+    function getProof(uint256 certificateID) external view returns (IGreenProof.Certificate memory proof) {
         LibIssuer.IssuerStorage storage issuer = LibIssuer._getStorage();
 
         if (certificateID > issuer.latestCertificateId) {
@@ -64,13 +64,13 @@ contract ProofManagerFacet is IProofManager, ERC1155EnumerableInternal {
         proof = issuer.certificates[certificateID];
     }
 
-    function getProofIdByDataHash(bytes32 dataHash) external view override returns (uint256 proofId) {
+    function getProofIdByDataHash(bytes32 dataHash) external view returns (uint256 proofId) {
         LibIssuer.IssuerStorage storage issuer = LibIssuer._getStorage();
 
         return issuer.dataToCertificateID[dataHash];
     }
 
-    function getProofsOf(address userAddress) external view override returns (IGreenProof.Certificate[] memory) {
+    function getProofsOf(address userAddress) external view returns (IGreenProof.Certificate[] memory) {
         uint256[] memory userTokenList = _tokensByAccount(userAddress);
         uint256 numberOfCertificates = userTokenList.length;
 
@@ -85,13 +85,13 @@ contract ProofManagerFacet is IProofManager, ERC1155EnumerableInternal {
         return userProofs;
     }
 
-    function claimedBalanceOf(address user, uint256 certificateID) external view override returns (uint256) {
+    function claimedBalanceOf(address user, uint256 certificateID) external view returns (uint256) {
         LibIssuer.IssuerStorage storage issuer = LibIssuer._getStorage();
 
         return issuer.claimedBalances[certificateID][user];
     }
 
-    function verifyProof(bytes32 rootHash, bytes32 leaf, bytes32[] memory proof) external pure override returns (bool) {
+    function verifyProof(bytes32 rootHash, bytes32 leaf, bytes32[] memory proof) external pure returns (bool) {
         return LibProofManager._verifyProof(rootHash, leaf, proof);
     }
 }

--- a/packages/greenproof-contracts/contracts/facets/VotingFacet.sol
+++ b/packages/greenproof-contracts/contracts/facets/VotingFacet.sol
@@ -45,7 +45,7 @@ contract VotingFacet is IVoting, IReward {
     /**
      * @notice Increases the number of votes for this matchResult. Voting completes when that vote leads to consensus or when voting expires
      */
-    function vote(bytes32 votingID, bytes32 matchResult) external override onlyWhitelistedWorker {
+    function vote(bytes32 votingID, bytes32 matchResult) external onlyWhitelistedWorker {
         bytes32 sessionID = LibVoting._getSessionID(votingID, matchResult);
         LibVoting.VotingSession storage session = LibVoting._getSession(votingID, sessionID);
 
@@ -75,7 +75,7 @@ contract VotingFacet is IVoting, IReward {
      * To be added, a worker should have the `workerRole` credential inside the claimManager
      * @param workerAddress - The address of the worker we want to remove
      */
-    function addWorker(address payable workerAddress) external override onlyEnrolledWorkers(workerAddress) {
+    function addWorker(address payable workerAddress) external onlyEnrolledWorkers(workerAddress) {
         LibVoting.VotingStorage storage votingStorage = LibVoting._getStorage();
 
         if (isWhitelistedWorker(workerAddress)) {
@@ -91,7 +91,7 @@ contract VotingFacet is IVoting, IReward {
      * The `workerRole` credential of the worker should be revoked before the removal.
      * @param workerToRemove - The address of the worker we want to remove
      */
-    function removeWorker(address workerToRemove) external override {
+    function removeWorker(address workerToRemove) external {
         LibVoting.VotingStorage storage votingStorage = LibVoting._getStorage();
         uint256 numberOfWorkers = LibVoting._getNumberOfWorkers();
 
@@ -117,7 +117,7 @@ contract VotingFacet is IVoting, IReward {
      * @notice Cancels votings that takes longer than time limit
      * @dev only the address referenced as the contract owner is allowed to perform this.
      */
-    function cancelExpiredVotings() external override onlyOwner {
+    function cancelExpiredVotings() external onlyOwner {
         LibVoting.VotingStorage storage votingStorage = LibVoting._getStorage();
 
         uint256 numberOfVotingIDs = votingStorage.votingIDs.length;
@@ -139,7 +139,7 @@ contract VotingFacet is IVoting, IReward {
         LibReward._setRewardsFeature(rewardsEnabled);
     }
 
-    function getWorkers() external view override returns (address payable[] memory) {
+    function getWorkers() external view returns (address payable[] memory) {
         LibVoting.VotingStorage storage votingStorage = LibVoting._getStorage();
 
         return votingStorage.whitelistedWorkers;
@@ -177,7 +177,7 @@ contract VotingFacet is IVoting, IReward {
     /**
      * @notice Retreieves the list of workers who voted for the winning macth
      */
-    function getWinners(bytes32 votingID, bytes32 matchResult) external view override returns (address payable[] memory) {
+    function getWinners(bytes32 votingID, bytes32 matchResult) external view returns (address payable[] memory) {
         LibVoting.VotingStorage storage votingStorage = LibVoting._getStorage();
         bytes32 sessionID = LibVoting._getSessionID(votingID, matchResult);
 
@@ -203,13 +203,13 @@ contract VotingFacet is IVoting, IReward {
         }
     }
 
-    function numberOfVotings() external view override returns (uint256) {
+    function numberOfVotings() external view returns (uint256) {
         LibVoting.VotingStorage storage votingStorage = LibVoting._getStorage();
 
         return votingStorage.votingIDs.length;
     }
 
-    function replenishRewardPool() external payable override onlyWhenEnabledRewards {
+    function replenishRewardPool() external payable onlyWhenEnabledRewards {
         if (msg.value == 0) {
             revert NoFundsProvided();
         }


### PR DESCRIPTION
This PR cleans the codebase by removing redundant overrides in onctracts.
It implements [audit feedback L08](https://energyweb.atlassian.net/browse/GP-686).