### PR TITLE
fix(greenProof-backend): extract error reason from reverted transactions

### DIFF
--- a/packages/greenproof-contracts/deploy/fixes/errorLogs.fix.ts
+++ b/packages/greenproof-contracts/deploy/fixes/errorLogs.fix.ts
@@ -1,44 +1,21 @@
-import "@typechain/hardhat";
 import { ethers } from "hardhat";
+import { extractError } from "../libraries/errorManager";
 
 const provider = new ethers.providers.JsonRpcProvider(process.env.VOLTA_RPC_URL);
 const adminWallet = new ethers.Wallet(process.env.PRIVATE_KEY!, provider);
-
-const displayError = (error: string) => {
-  console.log("\nExtracted Error: \x1b[31m%s\x1b[0m", `${error}`);
-}
 
 const fetchRPCTransaction = async (txHash: any) => {
     return await provider.getTransaction(txHash);
 }
 
-const parseRevertReason = (error: Error) => {
-  const stringifyedError = JSON.stringify({error}.error);
-  const jsonError = JSON.parse(stringifyedError);
-  const code = (jsonError.error.error.data).substr("Reverted ".length);
-  // console.log("\nExtracted ErrorCode to decode :: ", code, "\n");
-  const byteStringReasonLength = 136;
-  const reason = ethers.utils.toUtf8String('0x' + code.substr(byteStringReasonLength));
+const newClaimManagerAddress = ethers.constants.AddressZero;
 
-  return reason;
-}
 
-const extractError = async (tx: any) => {
-    try {
-        await provider.call(tx, tx.blockNumber)
-    } catch (err) {
-      const revertReason = parseRevertReason(err as Error);
-      displayError(revertReason);
-      return revertReason;
-    }
-    return "";
-}
 
 const main = async () => {
-  // conttract taken from https://louper.dev/diamond/0x0F4fF536A39b92950D71094a3A605A536735148f?network=volta
+  // greenproof contract taken from https://louper.dev/diamond/0x0F4fF536A39b92950D71094a3A605A536735148f?network=volta
   const greenproofAddress = "0x0F4fF536A39b92950D71094a3A605A536735148f";
   const greenproofContract = await ethers.getContractAt("Greenproof", greenproofAddress);
-  const addressZero = ethers.constants.AddressZero;
   const { maxFeePerGas, maxPriorityFeePerGas } = await ethers.provider.getFeeData();
   let tx;
 
@@ -47,7 +24,7 @@ const main = async () => {
     //this should trigger the `Cannot update to null address` error
     tx = await greenproofContract.connect(adminWallet)
       .updateClaimManager(
-        addressZero,
+        newClaimManagerAddress,
         {
           maxFeePerGas,
           maxPriorityFeePerGas,
@@ -55,15 +32,21 @@ const main = async () => {
         }
     );
     await tx.wait();
+    return tx;
   } catch (error) {
 
     const failingTx = await fetchRPCTransaction(tx.hash);
-    const reason = await extractError(failingTx);
+    const reason = await extractError(failingTx, provider);
     console.log("txDetails: ", failingTx)
     throw (new Error(reason));
   }
 }
 
 main().then(output => {
-  console.log("main output --> ", output);
+  console.log(
+    `ClaimManager Updated :
+---------------------
+      new address: ${newClaimManagerAddress}
+      UpdateTransaction: ${JSON.stringify(output)}`
+  );
 });

--- a/packages/greenproof-contracts/deploy/fixes/errorLogs.fix.ts
+++ b/packages/greenproof-contracts/deploy/fixes/errorLogs.fix.ts
@@ -1,0 +1,69 @@
+import "@typechain/hardhat";
+import { ethers } from "hardhat";
+
+const provider = new ethers.providers.JsonRpcProvider(process.env.VOLTA_RPC_URL);
+const adminWallet = new ethers.Wallet(process.env.PRIVATE_KEY!, provider);
+
+const displayError = (error: string) => {
+  console.log("\nExtracted Error: \x1b[31m%s\x1b[0m", `${error}`);
+}
+
+const fetchRPCTransaction = async (txHash: any) => {
+    return await provider.getTransaction(txHash);
+}
+
+const parseRevertReason = (error: Error) => {
+  const stringifyedError = JSON.stringify({error}.error);
+  const jsonError = JSON.parse(stringifyedError);
+  const code = (jsonError.error.error.data).substr("Reverted ".length);
+  // console.log("\nExtracted ErrorCode to decode :: ", code, "\n");
+  const byteStringReasonLength = 136;
+  const reason = ethers.utils.toUtf8String('0x' + code.substr(byteStringReasonLength));
+
+  return reason;
+}
+
+const extractError = async (tx: any) => {
+    try {
+        await provider.call(tx, tx.blockNumber)
+    } catch (err) {
+      const revertReason = parseRevertReason(err as Error);
+      displayError(revertReason);
+      return revertReason;
+    }
+    return "";
+}
+
+const main = async () => {
+  // conttract taken from https://louper.dev/diamond/0x0F4fF536A39b92950D71094a3A605A536735148f?network=volta
+  const greenproofAddress = "0x0F4fF536A39b92950D71094a3A605A536735148f";
+  const greenproofContract = await ethers.getContractAt("Greenproof", greenproofAddress);
+  const addressZero = ethers.constants.AddressZero;
+  const { maxFeePerGas, maxPriorityFeePerGas } = await ethers.provider.getFeeData();
+  let tx;
+
+  try {
+    //trying to update the claimManager with the  zero address 
+    //this should trigger the `Cannot update to null address` error
+    tx = await greenproofContract.connect(adminWallet)
+      .updateClaimManager(
+        addressZero,
+        {
+          maxFeePerGas,
+          maxPriorityFeePerGas,
+          gasLimit: 8000000
+        }
+    );
+    await tx.wait();
+  } catch (error) {
+
+    const failingTx = await fetchRPCTransaction(tx.hash);
+    const reason = await extractError(failingTx);
+    console.log("txDetails: ", failingTx)
+    throw (new Error(reason));
+  }
+}
+
+main().then(output => {
+  console.log("main output --> ", output);
+});

--- a/packages/greenproof-contracts/deploy/libraries/errorManager.ts
+++ b/packages/greenproof-contracts/deploy/libraries/errorManager.ts
@@ -1,0 +1,26 @@
+import { ethers } from "hardhat";
+
+export const displayError = (error: string) => {
+  console.log("\nExtracted Error: \x1b[31m%s\x1b[0m", `${error}`);
+}
+
+export const parseRevertReason = (error: Error) => {
+  const stringifyedError = JSON.stringify({error}.error);
+  const jsonError = JSON.parse(stringifyedError);
+  const errorCode = (jsonError.error.error.data).substr("Reverted ".length);
+  const byteStringReasonLength = 136;
+  const reason = ethers.utils.toUtf8String('0x' + errorCode.substr(byteStringReasonLength));
+
+  return reason;
+}
+
+export const extractError = async (tx: any, provider: any) => {
+    try {
+        await provider.call(tx, tx.blockNumber)
+    } catch (err) {
+      const revertReason = parseRevertReason(err as Error);
+      displayError(revertReason);
+      return revertReason;
+    }
+    return "";
+}


### PR DESCRIPTION
This PR adds a script example to extract error reasons from reverted transactions.
It handles the issues reported in Jira issue[ GP-525](https://energyweb.atlassian.net/browse/GP-525)