### PR TITLE
Chore/gp 753/optimize unit tests

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@energyweb/merkle-tree": "^3.0.0",
+    "@nomicfoundation/hardhat-network-helpers": "^1.0.8",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-solhint": "^3.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/packages/contracts/test/voting/consensus.js
+++ b/packages/contracts/test/voting/consensus.js
@@ -1,19 +1,10 @@
-const { expect } = require("chai");
 const { itEach } = require("mocha-it-each");
-const {
-  DEFAULT_REWARD_AMOUNT,
-} = require("../../scripts/deploy/deployContracts");
 
 module.exports.consensusTests = function () {
-  let diamondAddress;
-  let workers;
-  let votingContract;
-  let timeframes;
-  let setupVotingContract;
-  let faucet;
+  const { initFixture, loadFixture } = this.parent;
 
-  beforeEach(function () {
-    ({ workers, timeframes, setupVotingContract, faucet } = this);
+  beforeEach(async function () {
+    ({ workers, timeframes, setupVotingContract, faucet } =  await loadFixture(initFixture));
   });
 
   itEach(

--- a/packages/contracts/test/voting/expiration.js
+++ b/packages/contracts/test/voting/expiration.js
@@ -5,13 +5,10 @@ const {
 } = require("../../scripts/deploy/deployContracts");
 
 module.exports.expirationTests = function () {
-  let workers;
-  let votingContract;
-  let timeframes;
-  let setupVotingContract;
+  const { initFixture, loadFixture } = this.parent;
 
-  beforeEach(function () {
-    ({ workers, timeframes, setupVotingContract } = this);
+  beforeEach(async function () {
+    ({ workers, timeframes, setupVotingContract } = await loadFixture(initFixture));
   });
 
   it("voting which exceeded time limit can be canceled", async () => {

--- a/packages/contracts/test/voting/permissions.js
+++ b/packages/contracts/test/voting/permissions.js
@@ -8,28 +8,17 @@ const {
 const { workerRole } = roles;
 
 module.exports.permissionsTests = function () {
-  let owner;
-  let workers;
-  let mockClaimManager;
-  let votingContract;
-  let timeframes;
-  let addWorkers;
-  let removeWorkers;
-  let setupVotingContract;
 
-  beforeEach(function () {
-    ({
-      owner,
-      workers,
-      mockClaimManager,
-      timeframes,
-      addWorkers,
-      removeWorkers,
-      setupVotingContract,
-    } = this);
-  });
+  const { initFixture, loadFixture } = this.parent;
 
   it("should allow to vote whitelisted worker", async () => {
+
+    const {
+      workers,
+      timeframes,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+
     votingContract = await setupVotingContract({
       majorityPercentage: 100,
       participatingWorkers: [workers[0]],
@@ -48,6 +37,12 @@ module.exports.permissionsTests = function () {
   });
 
   it("should not allow to vote not whitelisted worker", async () => {
+    const {
+      workers,
+      timeframes,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+
     votingContract = await setupVotingContract({
       majorityPercentage: 100,
       participatingWorkers: [],
@@ -59,6 +54,12 @@ module.exports.permissionsTests = function () {
   });
 
   it("should not register a non enrolled worker", async () => {
+    const {
+      workers,
+      mockClaimManager,
+      setupVotingContract,
+    } = await loadFixture(initFixture);
+
     votingContract = await setupVotingContract({
       majorityPercentage: 100,
       participatingWorkers: [],
@@ -71,6 +72,13 @@ module.exports.permissionsTests = function () {
   });
 
   it("should revert when we try to remove a not whiteListed worker", async () => {
+    const {
+      owner,
+      workers,
+      mockClaimManager,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+    
     votingContract = await setupVotingContract({
       majorityPercentage: 100,
       participatingWorkers: [],
@@ -84,6 +92,12 @@ module.exports.permissionsTests = function () {
   });
 
   it("should not allow an enrolled worker to be unregistered", async () => {
+    const {
+      owner,
+      workers,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+    
     votingContract = await setupVotingContract({
       majorityPercentage: 100,
       participatingWorkers: [workers[0], workers[1]],
@@ -99,6 +113,11 @@ module.exports.permissionsTests = function () {
   });
 
   it("should not be able to add same worker twice", async () => {
+    const {
+      workers,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+    
     votingContract = await setupVotingContract({
       participatingWorkers: [workers[0]],
     });
@@ -108,9 +127,13 @@ module.exports.permissionsTests = function () {
     ).to.be.revertedWith("AlreadyWhitelistedWorker");
   });
 
-  //SIARA
-
   it("should allow non owner address to add enrolled workers", async () => {
+    const {
+      workers,
+      mockClaimManager,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+    
     votingContract = await setupVotingContract();
     await mockClaimManager.grantRole(workers[0].address, workerRole);
     await mockClaimManager.grantRole(workers[1].address, workerRole);
@@ -132,6 +155,13 @@ module.exports.permissionsTests = function () {
   });
 
   it("should allow non owner address to remove not enrolled workers", async () => {
+    const {
+      workers,
+      addWorkers,
+      removeWorkers,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+    
     votingContract = await setupVotingContract();
     await addWorkers([workers[0], workers[1], workers[2]]);
 
@@ -146,6 +176,14 @@ module.exports.permissionsTests = function () {
   });
 
   it("should allow to remove workers and add it again", async () => {
+    const {
+      workers,
+      addWorkers,
+      removeWorkers,
+      mockClaimManager,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+
     votingContract = await setupVotingContract();
 
     await addWorkers([workers[0], workers[1], workers[2]]);
@@ -173,6 +211,12 @@ module.exports.permissionsTests = function () {
   });
 
   it("voting can not be cancelled by non owner", async () => {
+    const {
+      workers,
+      timeframes,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+    
     votingContract = await setupVotingContract({
       participatingWorkers: [workers[0], workers[1], workers[2]],
     });
@@ -191,6 +235,12 @@ module.exports.permissionsTests = function () {
   });
 
   it("reverts when non owner tries to cancel expired votings", async () => {
+    const {
+      workers,
+      timeframes,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+    
     votingContract = await setupVotingContract({
       participatingWorkers: [workers[0]],
     });

--- a/packages/contracts/test/voting/replaying.js
+++ b/packages/contracts/test/voting/replaying.js
@@ -1,21 +1,17 @@
 const { expect } = require("chai");
 
 module.exports.replayingTests = function () {
-  let workers;
-  let votingContract;
-  let timeframes;
-  let addWorkers;
-  let setupVotingContract;
-  let expectVotingResults;
 
-  beforeEach(function () {
+  const { initFixture, loadFixture } = this.parent;
+
+  beforeEach(async function () {
     ({
       workers,
       timeframes,
       addWorkers,
       setupVotingContract,
       expectVotingResults,
-    } = this);
+    } = await loadFixture(initFixture));
   });
 
   it("should allow workers to replay the vote", async () => {

--- a/packages/contracts/test/voting/results.js
+++ b/packages/contracts/test/voting/results.js
@@ -7,18 +7,15 @@ const {
 const { formatEther } = utils;
 
 module.exports.resultsTests = function () {
-  let workers;
-  let votingContract;
-  let timeframes;
-  let setupVotingContract;
-  let faucet;
-  let removeWorkers;
-
-  beforeEach(function () {
-    ({ workers, timeframes, setupVotingContract, faucet, removeWorkers } = this);
-  });
+  const { initFixture, loadFixture } = this.parent;
 
   it("should not reveal workers vote before the end of vote", async () => {
+    const {
+      workers,
+      timeframes,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+    
     votingContract = await setupVotingContract({
       majorityPercentage: 100,
       participatingWorkers: [workers[0], workers[1]],
@@ -35,6 +32,12 @@ module.exports.resultsTests = function () {
   });
 
   it("should reveal workers vote after the end of vote", async () => {
+    const {
+      workers,
+      timeframes,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+    
     votingContract = await setupVotingContract({
       majorityPercentage: 100,
       participatingWorkers: [workers[0], workers[1]],
@@ -60,6 +63,12 @@ module.exports.resultsTests = function () {
   });
 
   it("should not reveal winners before the end of vote", async () => {
+    const {
+      workers,
+      timeframes,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+    
     votingContract = await setupVotingContract({
       majorityPercentage: 100,
       participatingWorkers: [workers[0], workers[1]],
@@ -79,6 +88,12 @@ module.exports.resultsTests = function () {
   });
 
   it("should not reveal winningMatches before the end of vote", async () => {
+    const {
+      workers,
+      timeframes,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+    
     votingContract = await setupVotingContract({
       participatingWorkers: [workers[0], workers[1], workers[2]],
     });
@@ -105,6 +120,12 @@ module.exports.resultsTests = function () {
   });
 
   it("should get the winner with the most votes", async () => {
+    const {
+      workers,
+      timeframes,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+    
     votingContract = await setupVotingContract({
       participatingWorkers: [workers[0], workers[1], workers[2]],
     });
@@ -120,6 +141,11 @@ module.exports.resultsTests = function () {
   });
 
   it("should be able to get the list of whiteListed workers", async () => {
+    const {
+      workers,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+    
     votingContract = await setupVotingContract({
       participatingWorkers: [workers[0]],
     });
@@ -136,6 +162,12 @@ module.exports.resultsTests = function () {
   });
 
   it("should get the number of voteIDs casted in the system", async () => {
+    const {
+      workers,
+      timeframes,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+
     votingContract = await setupVotingContract({
       participatingWorkers: [workers[0], workers[1], workers[2]],
     });
@@ -159,6 +191,12 @@ module.exports.resultsTests = function () {
   });
 
   it("should not be able to restart session", async () => {
+    const {
+      workers,
+      timeframes,
+      setupVotingContract
+    } = await loadFixture(initFixture);
+    
     votingContract = await setupVotingContract({
       majorityPercentage: 50,
       participatingWorkers: [workers[0], workers[1]],
@@ -180,6 +218,12 @@ module.exports.resultsTests = function () {
     const REWARD = ethers.utils.parseEther("123");
 
     it("pays proper reward to the winners", async () => {
+      const {
+        workers,
+        timeframes,
+        setupVotingContract
+      } = await loadFixture(initFixture);
+      
       votingContract = await setupVotingContract({
         reward: REWARD,
         participatingWorkers: [
@@ -211,6 +255,13 @@ module.exports.resultsTests = function () {
     });
 
     it("reward should be paid after replenishment of funds", async () => {
+      const {
+        faucet,
+        workers,
+        timeframes,
+        setupVotingContract
+      } = await loadFixture(initFixture);
+      
       votingContract = await setupVotingContract({
         reward: REWARD,
         participatingWorkers: [ workers[ 0 ], workers[ 1 ] ],
@@ -236,6 +287,12 @@ module.exports.resultsTests = function () {
     });
 
     it("should revert when calling replenishment of funds with no funds", async () => {
+      const {
+        faucet,
+        workers,
+        setupVotingContract
+      } = await loadFixture(initFixture);
+      
       votingContract = await setupVotingContract({
         reward: REWARD,
         participatingWorkers: [workers[0], workers[1]],
@@ -249,6 +306,12 @@ module.exports.resultsTests = function () {
     });
 
     it("should correctly proceed to rewardPool replenishment", async () => {
+      const {
+        faucet,
+        workers,
+        setupVotingContract
+      } = await loadFixture(initFixture);
+      
       votingContract = await setupVotingContract({
         reward: REWARD,
         participatingWorkers: [workers[0], workers[1]],
@@ -262,7 +325,12 @@ module.exports.resultsTests = function () {
     });
 
     it("should revert when calling replenishment of funds with rewards disabled", async () => {
-      
+      const {
+        faucet,
+        workers,
+        setupVotingContract
+      } = await loadFixture(initFixture);
+
       votingContract = await setupVotingContract({
         reward: REWARD,
         participatingWorkers: [workers[0], workers[1]],
@@ -277,6 +345,13 @@ module.exports.resultsTests = function () {
     });
 
     it("rewards should be paid partially and then fully after charging up the pool", async () => {
+      const {
+        faucet,
+        workers,
+        timeframes,
+        setupVotingContract
+      } = await loadFixture(initFixture);
+
       votingContract = await setupVotingContract({
         reward: REWARD,
         participatingWorkers: [workers[0], workers[1]],
@@ -309,6 +384,13 @@ module.exports.resultsTests = function () {
     });
 
     it("rewards should be paid partially then fully after calling PayReward manually", async () => {
+      const {
+        faucet,
+        workers,
+        timeframes,
+        setupVotingContract
+      } = await loadFixture(initFixture);
+      
       votingContract = await setupVotingContract({
         reward: REWARD,
         participatingWorkers: [workers[0], workers[1]],
@@ -349,6 +431,13 @@ module.exports.resultsTests = function () {
     });
 
     it("rewards transactions are correctly limited when we PayReward manually", async () => {
+      const {
+        faucet,
+        workers,
+        timeframes,
+        setupVotingContract
+      } = await loadFixture(initFixture);
+
       const OneWei = 1;
 
       votingContract = await setupVotingContract({
@@ -409,6 +498,13 @@ module.exports.resultsTests = function () {
     });
     
     it("Should not allow to PayReward manually when rewards are disabled", async () => {
+      const {
+        faucet,
+        workers,
+        timeframes,
+        setupVotingContract
+      } = await loadFixture(initFixture);
+
       const OneWei = 1;
 
       votingContract = await setupVotingContract({
@@ -469,6 +565,13 @@ module.exports.resultsTests = function () {
     });
 
     it("Should correctly reward after voting worker has been removed", async () => {
+      const {
+        workers,
+        timeframes,
+        removeWorkers,
+        setupVotingContract
+      } = await loadFixture(initFixture);
+
       const REWARD = ethers.utils.parseEther("1");
 
       votingContract = await setupVotingContract({
@@ -509,6 +612,11 @@ module.exports.resultsTests = function () {
     describe("Rewards management", function () {
 
       it("should correctly update reward feature", async () => {
+        const {
+        workers,
+        setupVotingContract
+        } = await loadFixture(initFixture);
+
         votingContract = await setupVotingContract({
           reward: REWARD,
           participatingWorkers: [ workers[ 0 ], workers[ 1 ] ],
@@ -525,6 +633,11 @@ module.exports.resultsTests = function () {
       });
 
       it("should revert when updating reward feature to the same state", async () => {
+      const {
+        workers,
+        setupVotingContract
+      } = await loadFixture(initFixture);
+        
         votingContract = await setupVotingContract({
           reward: REWARD,
           participatingWorkers: [ workers[ 0 ], workers[ 1 ] ],
@@ -541,6 +654,12 @@ module.exports.resultsTests = function () {
       });
 
       it("should not pay the winners if rewards are disabled", async () => {
+        const {
+          workers,
+          timeframes,
+          setupVotingContract
+        } = await loadFixture(initFixture);
+        
         votingContract = await setupVotingContract({
           reward: REWARD,
           participatingWorkers: [
@@ -572,6 +691,12 @@ module.exports.resultsTests = function () {
       });
 
       it("should revert when non owner tries to enable and disable rewards", async () => {
+        const {
+          faucet,
+          workers,
+          setupVotingContract
+        } = await loadFixture(initFixture);
+        
         const nonOwner = faucet;
         
         votingContract = await setupVotingContract({
@@ -587,6 +712,12 @@ module.exports.resultsTests = function () {
       });
 
       it("should revert when tries to enable rewards twice", async () => {
+        const {
+          faucet,
+          workers,
+          setupVotingContract
+        } = await loadFixture(initFixture);
+        
         const nonOwner = faucet;
         
         votingContract = await setupVotingContract({
@@ -602,6 +733,13 @@ module.exports.resultsTests = function () {
       });
 
       it("should pay the rewards after enabling rewards", async () => {
+        const {
+          faucet,
+          workers,
+          timeframes,
+          setupVotingContract
+        } = await loadFixture(initFixture);
+        
         votingContract = await setupVotingContract({
           reward: REWARD,
           participatingWorkers: [workers[0], workers[1]],

--- a/packages/contracts/test/voting/voting.spec.js
+++ b/packages/contracts/test/voting/voting.spec.js
@@ -12,6 +12,8 @@ const { resultsTests } = require("./results");
 const { replayingTests } = require("./replaying");
 const { expirationTests } = require("./expiration");
 const { consensusTests } = require("./consensus");
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
 
 const { workerRole } = roles;
 chai.use(solidity);
@@ -24,6 +26,7 @@ describe("Voting", function () {
   let faucet;
   let mockClaimManager;
   let mockClaimRevoker;
+  let initFixture;
 
   const timeframes = [
     {
@@ -52,7 +55,7 @@ describe("Voting", function () {
     },
   ];
 
-  beforeEach(async function () {
+  initFixture = async () => {
     const [ownerWallet, faucetWallet, ...workerWallets] =
       await ethers.getSigners();
 
@@ -65,7 +68,8 @@ describe("Voting", function () {
     for (let worker of workers) {
       await mockClaimRevoker.isRevoked(workerRole, worker.address, false);
     }
-    Object.assign(this, {
+
+    return {
       owner,
       workers,
       faucet,
@@ -77,8 +81,10 @@ describe("Voting", function () {
       removeWorkers,
       expectVotingResults,
       setupVotingContract,
-    });
-  });
+    }
+  };
+
+  Object.assign(this, { initFixture, loadFixture });
 
   describe("Permissions", permissionsTests);
   describe("Results", resultsTests);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2341,6 +2341,13 @@
     mcl-wasm "^0.7.1"
     rustbn.js "~0.2.0"
 
+"@nomicfoundation/hardhat-network-helpers@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.8.tgz#e4fe1be93e8a65508c46d73c41fa26c7e9f84931"
+  integrity sha512-MNqQbzUJZnCMIYvlniC3U+kcavz/PhhQSsY90tbEtUyMj/IQqsLwIRZa4ctjABh3Bz0KCh9OXUZ7Yk/d9hr45Q==
+  dependencies:
+    ethereumjs-util "^7.1.4"
+
 "@nomicfoundation/solidity-analyzer-darwin-arm64@0.0.3":
   version "0.0.3"
   resolved "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.0.3.tgz"
@@ -8919,7 +8926,7 @@ ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1, ethereumjs-util@^5.1.1, ethereum
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
 
-ethereumjs-util@^7.0.2, ethereumjs-util@^7.1.0:
+ethereumjs-util@^7.0.2, ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.4:
   version "7.1.5"
   resolved "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz"
   integrity sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==


### PR DESCRIPTION
This PR optimizes unit tests performance by using [hardhat fixtures](https://hardhat.org/tutorial/testing-contracts#reusing-common-test-setups-with-fixtures). This avoids redeploying all contracts setup `beforeEach` test iteration.